### PR TITLE
keeping pos <= dur

### DIFF
--- a/src/Ramp.cpp
+++ b/src/Ramp.cpp
@@ -134,6 +134,7 @@ T _ramp<T>::update() {
             }
         
             if (mode != NONE) {
+		if(pos > dur) pos = dur;
                 float k = (float)pos/(float)dur;
                 val = A + (B-A)*ramp_calc(k,mode);
                 constrain(val,A,B);                             //potential


### PR DESCRIPTION
there are some rare casese where pos > dur, which makes k > 1 and therefore breaks the code, because K is only checked to be == 1 or == 0 never if it happens to get bigger or smaller, just correcting this mistake would not make a change, because pos stays above dur. therefor pos itself need to be changed before calculating k